### PR TITLE
Fixed issue #2470. dotsData disabled click events

### DIFF
--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -74,8 +74,8 @@
 		this._handlers = {
 			'prepared.owl.carousel': $.proxy(function(e) {
 				if (e.namespace && this._core.settings.dotsData) {
-					this._templates.push('<div class="' + this._core.settings.dotClass + '">' +
-						$(e.content).find('[data-dot]').addBack('[data-dot]').attr('data-dot') + '</div>');
+					this._templates.push('<button class="' + this._core.settings.dotClass + '">' +
+						$(e.content).find('[data-dot]').addBack('[data-dot]').attr('data-dot') + '</button>');
 				}
 			}, this),
 			'added.owl.carousel': $.proxy(function(e) {


### PR DESCRIPTION
When dotsData was true it changed dot elements into divs, which the rest of owl was not looking for in terms of click events. This make sure it keeps them as buttons. This might not be the best solution, but it worked for me.